### PR TITLE
support variant status word 40000 returned by HL-L2380DW

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make install
 ```
 
 The driver **should** work for the most of Brother devices. 
-However, it has only been tested on the DCP-J105 and MFC-J430W.
+However, it has only been tested on the DCP-J105, MFC-J430W, and HL-L2380DW.
 
 If you have successfully run this driver with a different model,
 please open a github issue and provide debug output logs if possible, so that

--- a/device_handler.c
+++ b/device_handler.c
@@ -186,7 +186,7 @@ device_handler_add_device(struct device_config *config)
     status = snmp_get_printer_status(g_dev_handler.button_conn, buf,
                                      sizeof(buf), inet_addr(config->ip));
 
-    if (status != 10001 && status != 10006) {  // 10001: normal. 10006: low ink
+    if (status != 10001 && status != 10006 && status != 40000 ) {  // 10001: normal. 10006: low ink. 40000: unknown but OK.
       LOG_ERR("Error: device at %s is unreachable. (status: %d)\n", config->ip,
               status);
       return NULL;
@@ -261,7 +261,8 @@ device_handler_loop(void *arg)
           dev->next_ping_time = time_now + DEVICE_KEEPALIVE_DURATION_SEC;
           dev->status = snmp_get_printer_status(g_dev_handler.button_conn, buf,
                                                 sizeof(buf), dev->ip);
-          if (dev->status != 10001 && dev->status != 10006) {
+          if (dev->status != 10001 && dev->status != 10006
+		  && dev->status != 40000) {
             if (need_register) {
               // If the device is offline try re-establishing the connection
               // more frequently, so that we can re-register when it comes back
@@ -273,7 +274,8 @@ device_handler_loop(void *arg)
           }
         }
 
-        if (dev->status != 10001 && dev->status != 10006) {
+        if (dev->status != 10001 && dev->status != 10006
+	    && dev->status != 40000) {
           continue;
         }
 


### PR DESCRIPTION
after observing that the brother HL-L2380DW returns 40000 (0x9c40) in response
to a status query, accepting that as a valid response lets brother-scand
work nicely with this model as well.
Documented HL-L2380DW as working in Readme.MD