### PR TITLE
README: Switch to new repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ image data within the same (original) connection. But only on Windows... Well, n
 
 ## Installation
 ```
-git clone https://github.com/darsto/brother-scanner-driver.git
-cd brother-scanner-driver
+git clone https://github.com/rumpeltux/brother-scand.git
+cd brother-scand
 git submodule init
 git submodule update
-make install
+make && sudo make install
 ```
 
 The driver **should** work for the most of Brother devices. 


### PR DESCRIPTION
The instructions in the README currently point to the old repo which caused a few minutes of confusion before I noticed. This PR just updates it to point to the new maintainer repo (and also splits the make install step).