### PR TITLE
Add a new option to set the local IP address

### DIFF
--- a/config.c
+++ b/config.c
@@ -55,7 +55,7 @@ static void init_default_device_config(struct item_config *item_config,
 }
 
 void init_item_config(struct item_config *item_config,
-                      const struct item_config *template, char name[1024]) {
+                      const struct item_config *template, char *name) {
   memcpy(item_config, template, sizeof(*item_config));
   item_config->hostname = strdup(name);
 }

--- a/config.c
+++ b/config.c
@@ -174,7 +174,7 @@ config_init(const char *config_path)
           goto out;
         }
         dev_config->timeout = var_uint;
-      } else if (sscanf((char *)buf, "network.local-ip %64s", var_str) == 1) {
+      } else if (sscanf((char *)buf, "network.local-ip %15s", var_str) == 1) {
         if (dev_config == NULL) {
           fprintf(stderr, "Error: local ip specified without a device.\n");
           goto out;

--- a/config.c
+++ b/config.c
@@ -55,7 +55,7 @@ static void init_default_device_config(struct item_config *item_config,
 }
 
 void init_item_config(struct item_config *item_config,
-                      const struct item_config *template, char *name) {
+                      const struct item_config *template, char name[1024]) {
   memcpy(item_config, template, sizeof(*item_config));
   item_config->hostname = strdup(name);
 }
@@ -141,6 +141,7 @@ config_init(const char *config_path)
         }
         dev_config->ip = strdup(var_str);
         dev_config->timeout = CONFIG_NETWORK_DEFAULT_TIMEOUT_SEC;
+        dev_config->local_ip = NULL;
         TAILQ_INIT(&dev_config->items);
         TAILQ_INSERT_TAIL(&g_config.devices, dev_config, tailq);
       } else if (sscanf(buf, "preset %15s %15s", var_str, var2_str) == 2) {
@@ -173,6 +174,12 @@ config_init(const char *config_path)
           goto out;
         }
         dev_config->timeout = var_uint;
+      } else if (sscanf((char *)buf, "network.local-ip %64s", var_str) == 1) {
+        if (dev_config == NULL) {
+          fprintf(stderr, "Error: local ip specified without a device.\n");
+          goto out;
+        }
+        dev_config->local_ip = strdup(var_str);
       } else if (sscanf((char *)buf, "hostname %15s", var_str) == 1) {
         if (preset_config == NULL) {
           fprintf(stderr, "Error: hostname specified without a preset.\n");

--- a/config.h
+++ b/config.h
@@ -23,6 +23,7 @@ struct scan_param {
 
 struct device_config {
     char *ip;
+    char *local_ip;
     unsigned timeout;
     TAILQ_HEAD(, item_config) items;
     TAILQ_ENTRY(device_config) tailq;

--- a/device_handler.c
+++ b/device_handler.c
@@ -174,7 +174,12 @@ device_handler_add_device(struct device_config *config)
         return NULL;
     }
 
-    rc = brother_conn_get_local_ip(conn, local_ip);
+    if (config->local_ip != NULL) {
+      strncpy(local_ip, config->local_ip, 15);
+      rc = 0;
+    } else {
+      rc = brother_conn_get_local_ip(conn, local_ip);
+    }
     brother_conn_close(conn);
     if (rc != 0) {
         LOG_ERR("Can't get the local ip address that connected to %s:161.\n",
@@ -350,7 +355,11 @@ device_handler_stop(void *arg)
         TAILQ_REMOVE(&g_dev_handler.devices, dev, tailq);
         snmp_get_printer_status(g_dev_handler.button_conn, buf, sizeof(buf),
                                 dev->ip);
-        brother_conn_get_local_ip(g_dev_handler.button_conn, ip);
+        if (dev->config->local_ip != NULL) {
+          strncpy(ip, dev->config->local_ip, 15);
+        } else {
+          brother_conn_get_local_ip(g_dev_handler.button_conn, ip);
+        }
         register_scanner_driver(dev, ip, false);
         free(dev);
     }

--- a/device_handler.c
+++ b/device_handler.c
@@ -175,7 +175,7 @@ device_handler_add_device(struct device_config *config)
     }
 
     if (config->local_ip != NULL) {
-      strncpy(local_ip, config->local_ip, 15);
+      strncpy(local_ip, config->local_ip, 16);
       rc = 0;
     } else {
       rc = brother_conn_get_local_ip(conn, local_ip);
@@ -356,7 +356,7 @@ device_handler_stop(void *arg)
         snmp_get_printer_status(g_dev_handler.button_conn, buf, sizeof(buf),
                                 dev->ip);
         if (dev->config->local_ip != NULL) {
-          strncpy(ip, dev->config->local_ip, 15);
+          strncpy(ip, dev->config->local_ip, 16);
         } else {
           brother_conn_get_local_ip(g_dev_handler.button_conn, ip);
         }

--- a/out/brother.config
+++ b/out/brother.config
@@ -80,6 +80,12 @@
 # Values less than 30 are discouraged.
 #network.page.finish.timeout 60
 
+# The local IP address to report to the Brother device. This is useful
+# if you're running brother-scand inside of a Docker container, because
+# brother-scand will report the Docker container IP address without this
+# setting, which the device won't be able to reach.
+#network.local-ip 192.168.1.1
+
 ################################################################################
 # Preset definitions
 # You can define a number of presets that you can then reuse for the per-device


### PR DESCRIPTION
This commit adds a new option to explicitly set the local IP address instead of relying on autodetection. This is useful if you want to run the application inside of a Docker container, which will have a Docker-internal IP address instead of the external, device-visible one. The new option is called `network.local-ip`.

Without this option, brother-scand will manage to register functions at the device, but the device will not be able to reach brother-scand, because it will have received the registrations with an IP address it can't reach.

I'm using this in [brother-scand-config](https://github.com/jonasoberschweiber/brother-scand-config) to build a Docker container and have tested that it works locally. Not sure whether this is the best way to implement this -- my C is a little rusty.